### PR TITLE
First-party GraphQL Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.4.5 - 2019-11-14
+
+### Added
+- Added native GraphQL support for Address, Notes and Predefined Date fields.
+
 ## 3.4.4 - 2019-08-14
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "barrelstrength/sprout-fields",
     "description": "International, Craft-friendly field types.",
-    "version": "3.4.4",
+    "version": "3.4.5",
     "type": "craft-plugin",
     "keywords": [
         "craft",

--- a/src/fields/Address.php
+++ b/src/fields/Address.php
@@ -8,9 +8,13 @@ use CommerceGuys\Addressing\Formatter\DefaultFormatter;
 use CommerceGuys\Addressing\Address as CommerceGuysAddress;
 use CommerceGuys\Addressing\Subdivision\SubdivisionRepository;
 use CommerceGuys\Addressing\Country\CountryRepository;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Definition\ObjectType;
 use craft\base\ElementInterface;
 use craft\base\Field;
 use craft\base\PreviewableFieldInterface;
+use craft\gql\GqlEntityRegistry;
+use craft\gql\TypeLoader;
 use Craft;
 use yii\db\Schema;
 
@@ -75,4 +79,31 @@ class Address extends Field implements PreviewableFieldInterface
 
         return $html;
     }
+
+    /**
+     * @inheritdoc
+     * @since 3.3.0
+     */
+    public function getContentGqlType()
+    {
+        $typeName = $this->handle.'_SproutAddressField';
+
+        $addressType = GqlEntityRegistry::getEntity($typeName)
+            ?: GqlEntityRegistry::createEntity($typeName, new ObjectType([
+                'name'   => $typeName,
+                'fields' => [
+                    'countryCode' => Type::string(),
+                    'administrativeAreaCode' => Type::string(),
+                    'locality' => Type::string(),
+                    'postalCode' => Type::string(),
+                    'address1' => Type::string(),
+                    'address2' => Type::string(),
+                ],
+            ]));
+
+        TypeLoader::registerType($typeName, static function () use ($addressType) { return $addressType ;});
+
+        return $addressType;
+    }
+
 }

--- a/src/fields/Notes.php
+++ b/src/fields/Notes.php
@@ -8,6 +8,7 @@ use craft\base\Field;
 use barrelstrength\sproutbasefields\web\assets\quill\QuillAsset;
 
 use craft\helpers\FileHelper;
+use GraphQL\Type\Definition\Type;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
@@ -131,6 +132,22 @@ class Notes extends Field
             ]
         );
     }
+
+    /**
+     * @inheritdoc
+     * @since 3.3.0
+     */
+    public function getContentGqlType()
+    {
+        return [
+            'name' => $this->handle,
+            'type' => Type::string(),
+            'resolve' => function() {
+                return $this->notes;
+            },
+        ];
+    }
+
 
     /**
      * Returns a css style

--- a/src/fields/PredefinedDate.php
+++ b/src/fields/PredefinedDate.php
@@ -5,7 +5,9 @@ namespace barrelstrength\sproutfields\fields;
 use Craft;
 use craft\base\ElementInterface;
 use craft\helpers\DateTimeHelper;
+use craft\gql\types\DateTime as GqlDateTimeType;
 use Exception;
+use GraphQL\Type\Definition\Type;
 use Throwable;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
@@ -82,4 +84,17 @@ class PredefinedDate extends BasePredefinedField
                 'value' => $value
             ]);
     }
+
+    /**
+     * @inheritdoc
+     * @since 3.3.0
+     */
+    public function getContentGqlType()
+    {
+        return [
+            'name' => $this->handle,
+            'type' => GqlDateTimeType::getType(),
+        ];
+    }
+
 }


### PR DESCRIPTION
This PR adds native GraphQL support for fields that didn't already resolve neatly as strings: Address, Notes and PredefinedDate. It may satisfy #93 depending on how elaborately you'd like to support GraphQL.

## Changed Behavior

Previously, querying a Notes or Predefined Date field would return `null` in each case. This instead returns the rendered note and date respectively. The date is formatted according to `FormatDateTime::DEFAULT_FORMAT` via `craft\gql\types\DateTime` since that's how Craft returns its own `DateTime` values via GraphQL.

The Address field was previously returning the complete address as formatted markup. This registers a new GraphQL object entity so that Sprout Fields can make each Address nugget available individually.

### Current Behavior (without PR)

Query (each `sprout*` handle being a custom field type):
```graphql
{
  entries {
    ... on test_test_Entry {
      sproutAddress
      sproutEmail
      sproutPhone
      sproutPredefined
      sproutGender
      sproutName
      sproutNotes 
      sproutPredefinedDate
      sproutRegularExpression
      sproutUrl
    }
  }
}
```

Response:
```json
{
  "data": {
    "entries": [
      {
        "sproutAddress": "<p translate=\"no\">\n<span class=\"address-line1\">12345 Balboa Parkway</span><br>\n<span class=\"locality\">Los Angeles</span>, <span class=\"administrative-area\">CA</span> <span class=\"postal-code\">92654</span><br>\n<span class=\"country\">United States</span>\n</p>",
        "sproutEmail": "lucille.bluth@hotmail.com",
        "sproutPhone": "+1 555-555-5555",
        "sproutPredefined": "test-fields",
        "sproutGender": "female",
        "sproutName": "Lucille Bluth",
        "sproutNotes": null,
        "sproutPredefinedDate": null,
        "sproutRegularExpression": ".*",
        "sproutUrl": "https://recurringdevelopments.com/",
      }
    ]
  }
}
```

### Updated Behavior (with PR)

Query:
```graphql
{
  entries {
    ... on test_test_Entry {
      sproutAddress {
        address1
        address2
        locality
        administrativeAreaCode
        postalCode
        countryCode
      }
      sproutEmail
      sproutPhone
      sproutPredefined
      sproutGender
      sproutName
      sproutNotes 
      sproutPredefinedDate
      sproutRegularExpression
      sproutUrl
    }
  }
}
```

Response:
```json
{
  "data": {
    "entries": [
      {
        "sproutAddress": {
          "address1": "12345 Balboa Parkway",
          "address2": "",
          "locality": "Los Angeles",
          "administrativAreaCode": "CA",
          "postalCode": "92654",
          "countryCode": "US",
        },
        "sproutEmail": "lucille.bluth@hotmail.com",
        "sproutPhone": "+1 555-555-5555",
        "sproutPredefined": "test-fields",
        "sproutGender": "female",
        "sproutName": "Lucille Bluth",
        "sproutNotes": "<p>Always leave a note.</p>",
        "sproutPredefinedDate": "2019-11-14T10:11:39+00:00",
        "sproutRegularExpression": ".*",
        "sproutUrl": "https://recurringdevelopments.com/",
      }
    ]
  }
}
```

## How it Works

Each modified field type needed to clarify how it should be reduced to scalar types for GraphQL. Craft automatically tries—and mostly succeeds with the rest of the field types—to get and use the string value of a given field. Each adjustment here implements `getContentGqlType()` on the respective field class.

Predefined Date is the simplest, returning Craft's `GqlDateTimeType::getType()`.

Notes is more atypical for a field type. It returns a string type and uses a `resolve` parameter that provides the `notes` property as that string.

Address returns an object with properties that map to strings. To do this, it creates and registers a new object type, each property mapping directly to those that already exist on the field's address pieces. Note that this type is re-used by `GqlEntityRegistry::getEntity()` if it already exists, for healthy performance.

## Limitations

Reasons you may not want to merge immediately:

1. This requires Craft 3.3.0+ and I'm not sure how you handle versioning and support.
2. Sprout Fields does a lovely job of validating and storing these bits of information, and this GraphQL implementation could be further improved to take arguments that tailor output in the same way Twig can right now.

---

If you have any questions, objections or requests let me know!